### PR TITLE
Implement scanline overlay in main element

### DIFF
--- a/app/static/css/base.css
+++ b/app/static/css/base.css
@@ -73,6 +73,29 @@ header h1 {
   filter: brightness(0) saturate(100%) invert(61%) sepia(12%) saturate(600%) hue-rotate(110deg);
 }
 
+/* scanline overlay */
+main {
+  position: relative;
+}
+
+main::after {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  background: repeating-linear-gradient(
+    to bottom,
+    transparent 0px,
+    transparent 2px,
+    rgba(0, 0, 0, 0.15) 2px,
+    rgba(0, 0, 0, 0.15) 4px
+  );
+}
+
 main {
   width: 100%;
 }


### PR DESCRIPTION
Added a scanline overlay effect to the main element
- you should be able to slight lines over the webpage now (not the header area)
- adding more a retro game feel

<img width="1440" height="775" alt="Screenshot 2026-04-24 at 1 00 42 pm" src="https://github.com/user-attachments/assets/3c12a74e-ae72-44ea-b0c3-de21b32bed99" />

